### PR TITLE
[webplugin.md] Update JQuery version in example

### DIFF
--- a/webplugin.md
+++ b/webplugin.md
@@ -159,7 +159,7 @@ Include the jQuery library with version greater or equal than 1.4.3 if it's not 
 
 ```html
 <!-- Include jQuery library >= 1.4.3 version -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 ```
 
 Then include the Pollfish Webplugin, as the example below:


### PR DESCRIPTION
Change JQuery version from 1.11.2 to 3.4.1 .

Motivation:
Developers tend to copy/paste from examples, and JQuery 1.11.2 has known security vulnerabilities, see https://snyk.io/test/npm/jquery/1.11.2 for details.

Also, the newer version is 6kb~ smaller 🎉 